### PR TITLE
Use DI for Helper and ability to specify Message Group ID for FIFO

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -6,16 +6,42 @@
  */
 namespace Belvg\Sqs\Helper;
 
+use Belvg\Sqs\Model\Config;
+
 class Data
 {
+    /**
+     * @var Config
+     */
+    private $sqsConfig;
+
+    /**
+     * Data constructor.
+     * @param Config $sqsConfig
+     */
+    public function __construct(
+        Config $sqsConfig
+    ) {
+        $this->sqsConfig = $sqsConfig;
+    }
+
     /**
      * Prepare queue name
      *
      * @param string $queueName
-     * @return mixed
+     * @param bool $addPrefix
+     * @return string
      */
-    public static function prepareQueueName(string $queueName)
+    public function prepareQueueName(string $queueName, $addPrefix = false)
     {
-        return str_replace('.', '_', $queueName);
+        $queueName = str_replace('.', '_', $queueName);
+        if ($addPrefix) {
+            $prefix = $this->sqsConfig->getValue(Config::PREFIX);
+            if ($prefix) {
+                $queueName = $prefix . '_' . $queueName;
+            }
+        }
+
+        return $queueName;
     }
 }

--- a/Model/Topology.php
+++ b/Model/Topology.php
@@ -8,6 +8,7 @@
 namespace Belvg\Sqs\Model;
 
 use Belvg\Sqs\Helper\Data;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Communication\ConfigInterface as CommunicationConfig;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\MessageQueue\ConfigInterface as QueueConfig;
@@ -49,23 +50,31 @@ class Topology
     private $communicationConfig;
 
     /**
+     * @var Data
+     */
+    private $helper;
+
+    /**
      * Topology constructor.
      * @param Config $sqsConfig
      * @param QueueConfig $queueConfig
      * @param CommunicationConfig $communicationConfig
      * @param \Psr\Log\LoggerInterface $logger
+     * @param Data $helper
      */
     public function __construct(
         Config $sqsConfig,
         QueueConfig $queueConfig,
         CommunicationConfig $communicationConfig,
-        \Psr\Log\LoggerInterface $logger
+        \Psr\Log\LoggerInterface $logger,
+        Data $helper = null
     )
     {
         $this->sqsConfig = $sqsConfig;
         $this->queueConfig = $queueConfig;
         $this->communicationConfig = $communicationConfig;
         $this->logger = $logger;
+        $this->helper = $helper ?: ObjectManager::getInstance()->get(Data::class);
     }
 
     /**
@@ -276,6 +285,6 @@ class Topology
      */
     protected function getQueueName($queueName)
     {
-        return $this->sqsConfig->getValue(Config::PREFIX) . '_' . Data::prepareQueueName($queueName);
+        return $this->helper->prepareQueueName($queueName, true);
     }
 }


### PR DESCRIPTION
@Galillei @sanuter 

1. Sometimes we don't need to use PREFIX for queues
2. Ability to specify "message_group_id" for FIFO SQS Queues
3. Ability to change the replacement logic of queue name using DI (plugin, preference or arguments)

Thank you!